### PR TITLE
Extend Flux compatibility to include 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"
-Flux = "0.12"
+Flux = "0.12, 0.13"
 IterTools = "1.3"
 OutlierDetectionInterface = "0.1"
 CategoricalArrays = "0.10"

--- a/src/models/ae.jl
+++ b/src/models/ae.jl
@@ -1,7 +1,7 @@
 using Flux: Chain, train!, params
 using Flux.Losses:mse
 using Flux.Data:DataLoader
-using Flux.Optimise:ADAM
+using Flux.Optimise:Adam
 using IterTools:ncycle
 using Statistics:mean
 
@@ -12,7 +12,7 @@ using Statistics:mean
                epochs = 1,
                shuffle = false,
                partial = true,
-               opt = ADAM(),
+               opt = Adam(),
                loss = mse)
 
 Calculate the anomaly score of an instance based on the reconstruction loss of an autoencoder, see [1] for an
@@ -39,7 +39,7 @@ OD.@detector struct AEDetector <: UnsupervisedDetector
     epochs::Integer = 1
     shuffle::Bool = false
     partial::Bool = true
-    opt::Any = ADAM()
+    opt::Any = Adam()
     loss::Function = mse
 end
 

--- a/src/models/dsad.jl
+++ b/src/models/dsad.jl
@@ -9,7 +9,7 @@ using Statistics: mean
                     epochs = 1,
                     shuffle = true,
                     partial = false,
-                    opt = ADAM(),
+                    opt = Adam(),
                     loss = mse,
                     eta = 1,
                     eps = 1e-6,
@@ -61,7 +61,7 @@ mutable struct DSADDetector <: SupervisedDetector
     eps::Number
     callback::Tuple{Function,Function}
     function DSADDetector(; encoder::Chain = Chain(), decoder::Chain = Chain(), batchsize = 32, epochs = 1, shuffle = false,
-        partial = true, opt = ADAM(), loss = mse, eta = 1, eps = 1e-6, callback = (_ -> () -> ()))
+        partial = true, opt = Adam(), loss = mse, eta = 1, eps = 1e-6, callback = (_ -> () -> ()))
 
         # unify all possible tuples to tuples
         tuplify = t -> isa(t, Tuple) ? t : (t, t)

--- a/src/models/esad.jl
+++ b/src/models/esad.jl
@@ -10,7 +10,7 @@ using LinearAlgebra: norm
                 epochs = 1,
                 shuffle = false,
                 partial = true,
-                opt = ADAM(),
+                opt = Adam(),
                 λ1 = 1,
                 λ2 = 1,
                 noise = identity)
@@ -47,7 +47,7 @@ OD.@detector mutable struct ESADDetector <: SupervisedDetector
     epochs::Integer = 1::(_ > 0)
     shuffle::Bool = false
     partial::Bool = true
-    opt::Any = ADAM()
+    opt::Any = Adam()
     λ1::Number = 1
     λ2::Number = 1
     noise::Function = identity


### PR DESCRIPTION
I need this because Flux 0.12 uses an old version of AbstractTrees.jl.